### PR TITLE
Add quote support to [url] bbcode tag

### DIFF
--- a/include_generic/libbb.php
+++ b/include_generic/libbb.php
@@ -110,6 +110,7 @@ function bbencode( $text )
   $text = preg_replace("/\[list=(.*?)\](.*?)\[\/list\]/si","<ol type='$1'>$2</ol>",$text);
   $text = preg_replace("/\[\*\](.*)[\r\n]/","<li>$1</li>",$text);
   $text = preg_replace("/\[url\](.*?)\[\/url\]/si","<a href='$1'>$1</a>",$text);
+  $text = preg_replace("/\[url=\"([^\"]*?)\"\](.*?)\[\/url\]/si","<a href='$1'>$2</a>",$text);
   $text = preg_replace("/\[url=(.*?)\](.*?)\[\/url\]/si","<a href='$1'>$2</a>",$text);
   if (get_setting("displayimages") || $_GET["forceimages"])
     $text = preg_replace("/\[img\](.*?)\[\/img\]/i","<img src='$1' class='bbimage' alt='BB Image'/>",$text);


### PR DESCRIPTION
Attempt to fix #65. the idea is that we add new syntax `[url="https://google.com"]...[/url]`, notice the quotes. 

Then, @tomaes can write  `[url="http://www.pouet.net/prodlist.php?platform[]=Commodore%20128"]click here[/url]` and be done with it.

I tested it by manually fooling around a bit (i have no idea how to run pouet.net locally but libbb.php is pretty much self-contained)