### PR TITLE
Enable Strict Transport Security

### DIFF
--- a/bootstrap.inc.php
+++ b/bootstrap.inc.php
@@ -1,6 +1,9 @@
 <?
 error_reporting(E_ALL & ~E_NOTICE);
 
+// Enforce HTTPS for this domain (this header is ignored when served over HTTP) 
+header('Strict-Transport-Security: max-age=15768000');
+
 define("POUET_ROOT_LOCAL",dirname(__FILE__));
 if (!file_exists(POUET_ROOT_LOCAL . "/include_generic/credentials.inc.php"))
   die("Please create an include_generic/credentials.inc.php - you can use the credentials.inc.php.dist as an example");


### PR DESCRIPTION
This enables STS for half a year (the minimum recommended value according to e.g. Qualys SSL test).
Once a user visits Pouet over HTTPS, their browser will stay on HTTPS. If they only ever visit Pouet over HTTP, nothing is changed, as browsers should ignore this header when served over HTTP.