### PR TITLE
Change the credits change request comparison to case sensitive variant

### DIFF
--- a/include_pouet/request-classes.inc.php
+++ b/include_pouet/request-classes.inc.php
@@ -421,7 +421,7 @@ class PouetRequestClassChangeCredit extends PouetRequestClassBase
     if (!$row)
       return array("nice try :|");
 
-    if (strcasecmp($row->role,$input["userRole"])===0 && $row->userID == $input["userID"])
+    if (strcmp($row->role,$input["userRole"])===0 && $row->userID == $input["userID"])
       return array("you didn't change anything :|");
 
     if (!SQLLib::selectRow(sprintf_esc("select * from users where id = %d",$input["userID"])))


### PR DESCRIPTION
This change enables users to submit changes to the credits strings that include capitalization corrections without being presented an unhelpful warning and needings to jump through hoops to get the change done (these changes are de-facto accepted by glöperators anyway).