### PR TITLE
Remove Google+ share link (#90)

### DIFF
--- a/prod.php
+++ b/prod.php
@@ -553,8 +553,6 @@ class PouetBoxProdPopularityHelper extends PouetBox {
     
     $text = "You should watch \"".$this->prod->name."\" on @pouetdotnet: ".$url;
     echo "  <a href='https://twitter.com/intent/tweet?text="._html(rawurlencode($text))."'>twitter</a>\n";
-    
-    echo "  <a href='https://plus.google.com/share?url="._html(rawurlencode($url))."'>google+</a>\n";
 
     echo "  <a href='http://pinterest.com/pin/create/button/?url="._html(rawurlencode($url))."'>pinterest</a>\n";
 


### PR DESCRIPTION
Removes the G+ share link since google+ is [officially dead](https://plus.google.com/).

But yeh it's like, one line

fixes #90