### PR TITLE
fix credits not populated in prod data dump

### DIFF
--- a/admin.functions.php
+++ b/admin.functions.php
@@ -173,7 +173,7 @@ function pouetAdmin_createDataDump()
     
     $s = new BM_Query("credits");
     $s->AddField("credits.role");
-    $s->AddWhere(sprintf("credits.prodID = %d",$prod->id));
+    $s->AddWhere(sprintf("credits.prodID = %d",$item->id));
     $s->Attach(array("credits"=>"userID"),array("users as user"=>"id"));
     $s->AddOrder("credits.role");
     $item->credits = $s->perform();


### PR DESCRIPTION
Attempt to fix #95 - Credits are not populated in prod dump. It looks like the wrong variable was being bound when selecting the credits. This change has not yet been tested.