### PR TITLE
Fix bbs anti-spam always denying posts

### DIFF
--- a/include_pouet/box-bbs-open.php
+++ b/include_pouet/box-bbs-open.php
@@ -23,7 +23,7 @@ class PouetBoxBBSOpen extends PouetBox {
     if (!$message)
       return "not too meaningful, is it...";
 
-    if ($currentUser->glops == 0 && substr($message,"://")!==false)
+    if ($currentUser->glops == 0 && strpos($message,"://")!==false)
       return array("you need at least 1 glöp to post links !");
 
     $title = trim($post["topic"]);

--- a/include_pouet/box-bbs-post.php
+++ b/include_pouet/box-bbs-post.php
@@ -23,7 +23,7 @@ class PouetBoxBBSPost extends PouetBox {
     if (!$message)
       return array("not too meaningful, is it...");
 
-    if ($currentUser->glops == 0 && substr($message,"://")!==false)
+    if ($currentUser->glops == 0 && strpos($message,"://")!==false)
       return array("you need at least 1 glöp to post links !");
 
     $topic = SQLLib::SelectRow(sprintf_esc("SELECT * FROM bbs_topics where id=%d",$this->topic));


### PR DESCRIPTION
The `substr` generates a warning and always returns `true`, so 0-glöp users (like me) can't post right now.