### PR TITLE
Wrap radio buttons in labels

### DIFF
--- a/include_pouet_index/box-index-searchbox.php
+++ b/include_pouet_index/box-index-searchbox.php
@@ -18,18 +18,18 @@ class PouetBoxIndexSearchBox extends PouetBoxCachable {
     $types = array("prod","group","party"/*,"board"*/,"user","bbs");
     $a = array();
     foreach($types as $t)
-      $a[] = "<li><input type='radio' name='type' value='".$t."' id='search".$t."' ".($t=="prod"?" checked='checked'":"")." />&nbsp;<label for='search".$t."'>".$t."</label></li>\n";
+      $a[] = "<li><label><input type='radio' name='type' value='".$t."' ".($t=="prod"?" checked='checked'":"")."/>&nbsp;".$t."</label></li>\n";
 
     echo "<ul id='searchType'>";
     echo implode("\n",$a);
     echo "</ul>";
     /*
-    echo "<input type='radio' name='type' value='prod' id='prod' checked='checked' />&nbsp;<label for='prod'>prod</label>\n";
-    echo "<input type='radio' name='type' value='group' id='group'/>&nbsp;<label for='group'>group</label>\n";
-    echo "<input type='radio' name='type' value='party' id='party'/>&nbsp;<label for='party'>party</label>\n";
-    echo "<input type='radio' name='type' value='board' id='board'/>&nbsp;<label for='board'>board</label>\n";
-    echo "<input type='radio' name='type' value='user' id='user'/>&nbsp;<label for='user'>user</label>\n";
-    echo "<input type='radio' name='type' value='bbs' id='bbs'/>&nbsp;<label for='bbs'>bbs</label>\n";
+    echo "<label><input type='radio' name='type' value='prod' checked='checked'/>&nbsp;prod</label>\n";
+    echo "<label><input type='radio' name='type' value='group'/>&nbsp;group</label>\n";
+    echo "<label><input type='radio' name='type' value='party'/>&nbsp;party</label>\n";
+    echo "<label><input type='radio' name='type' value='board'/>&nbsp;board</label>\n";
+    echo "<label><input type='radio' name='type' value='user'/>&nbsp;user</label>\n";
+    echo "<label><input type='radio' name='type' value='bbs'/>&nbsp;bbs</label>\n";
     */
     echo "</div>\n";
     echo "<div class='foot'><input type='submit' value='Submit' /></div>";

--- a/prod.php
+++ b/prod.php
@@ -981,9 +981,9 @@ class PouetBoxProdPost extends PouetBox {
       {
         echo " <div id='prodvote'>\n";
         echo " this prod\n";
-        echo " <input type='radio' name='rating' id='ratingrulez' value='rulez'/> <label for='ratingrulez'>rulez</label>\n";
-        echo " <input type='radio' name='rating' id='ratingpig' value='isok' checked='true'/> <label for='ratingpig'>is ok</label>\n";
-        echo " <input type='radio' name='rating' id='ratingsucks' value='sucks'/> <label for='ratingsucks'>sucks</label>\n";
+        echo " <label><input type='radio' name='rating' value='rulez'/> rulez</label>\n";
+        echo " <label><input type='radio' name='rating' value='isok' checked='true'/> is ok</label>\n";
+        echo " <label><input type='radio' name='rating' value='sucks'/> sucks</label>\n";
         echo " </div>\n";
       }
       echo " <textarea name='comment' id='comment'></textarea>\n";

--- a/search.php
+++ b/search.php
@@ -19,7 +19,7 @@ class PouetBoxSearchBoxMain extends PouetBox
     $a = array();
     $selected = $_GET["type"] ? $_GET["type"] : "prod";
     foreach($types as $t)
-      $a[] = "<input type='radio' name='type' value='".$t."' id='search".$t."' ".($t==$selected?" checked='checked'":"")." />&nbsp;<label for='search".$t."'>".$t."</label>\n";
+      $a[] = "<label><input type='radio' name='type' value='".$t."' ".($t==$selected?" checked='checked'":"")."/>&nbsp;".$t."</label>\n";
 
     echo implode(" |\n",$a);
 


### PR DESCRIPTION
This makes the gap between radio button and label part of the clickable area that triggers selection. Avoids unintended actionless clicks.

The field ID is no longer needed as the label applies to the field it encapsulates.