### PR TITLE
Include year in link to party

### DIFF
--- a/include_pouet/pouet-party.php
+++ b/include_pouet/pouet-party.php
@@ -12,7 +12,7 @@ class PouetParty extends BM_Class {
     if ($this->id == 0) return "??";
     if ($year)
     {
-      return sprintf("<a href='party.php?which=%d&amp;when=%d'>%s</a> %d",
+      return sprintf("<a href='party.php?which=%d&amp;when=%d'>%s %d</a>",
         $this->id,$year,_html($this->name),$year);
     }
     else


### PR DESCRIPTION
When the year is available, the link points to a specific party, so the link label should reflect that.