### PR TITLE
fix rendering of UTF-8 encoded files with DOS/Amiga fonts

### DIFF
--- a/include_generic/functions.inc.php
+++ b/include_generic/functions.inc.php
@@ -295,6 +295,10 @@ function cp437_to_utf8( $text )
 
 function process_ascii( $text, $enc = null )
 {
+  if (mb_detect_encoding( $text, "utf-8", true ) !== false)
+  {
+    return $text;
+  }
   if ($enc == null)
   {
     $enc = mb_detect_encoding( $text, "utf-8, iso-8859-1" );


### PR DESCRIPTION
Mojibake appeared when using the ASCII viewer with the DOS or Amiga fonts on UTF-8 encoded files.

This commit fixes that by not converting text from `cp437` or `iso-8859-1` to `utf-8` if it's already valid UTF-8.

For details, see https://www.pouet.net/topic.php?which=10189&page=8#c573844.