### PR TITLE
Set the scope to also be able to retrieve the user's email

### DIFF
--- a/bootstrap.inc.php
+++ b/bootstrap.inc.php
@@ -89,6 +89,10 @@ else if (class_exists("SceneID3"))
   ) );
 }
 
+// Set the scope to also be able to retrieve the user's email.
+// Without this, we can't contact anyone for notifications or moderation events.
+$sceneID->SetScope(array("basic", "user:email"));
+
 $currentUser = NULL;
 if (get_login_id())
 {

--- a/include_pouet/pouet-user.php
+++ b/include_pouet/pouet-user.php
@@ -144,7 +144,17 @@ class PouetUser extends BM_Class
     try
     {
       $sceneID->GetClientCredentialsToken();
-      $data = $sceneID->User( $this->id );
+
+      // If the current user is the same as the PouetUser, get more info from SceneID
+      if (get_login_id() == $this->id)
+      {
+        $data = $sceneID->Me();
+      }
+      else
+      {
+        $data = $sceneID->User( $this->id );
+      }
+
       if ($data && @$data["user"])
       {
         SQLLib::UpdateRow("users",array(


### PR DESCRIPTION
Without this, we can't contact anyone for notifications or moderation events.

The problem with that is that in order to update the scope for a user, the user has to disconnect pouet from https://id.scene.org/profile/ and I don't see a way for Pouët to update or invalidate the existing SceneID pouet login to update the scope.

Do you?