### PR TITLE
Disable BitFellas

### DIFF
--- a/include_pouet_index/index_bootstrap.inc.php
+++ b/include_pouet_index/index_bootstrap.inc.php
@@ -11,7 +11,8 @@ require_once( POUET_ROOT_LOCAL . "/include_pouet_index/box-index-latestparties.p
 require_once( POUET_ROOT_LOCAL . "/include_pouet_index/box-index-upcomingparties.php");
 require_once( POUET_ROOT_LOCAL . "/include_pouet_index/box-index-topmonth.php");
 require_once( POUET_ROOT_LOCAL . "/include_pouet_index/box-index-topalltime.php");
-require_once( POUET_ROOT_LOCAL . "/include_pouet_index/box-index-news.php");
+// Commented out until bitfellas is back up
+// require_once( POUET_ROOT_LOCAL . "/include_pouet_index/box-index-news.php");
 require_once( POUET_ROOT_LOCAL . "/include_pouet_index/box-index-searchbox.php");
 require_once( POUET_ROOT_LOCAL . "/include_pouet_index/box-index-affilbutton.php");
 require_once( POUET_ROOT_LOCAL . "/include_pouet_index/box-index-stats.php");


### PR DESCRIPTION
This pull request includes a small change to the `include_pouet_index/index_bootstrap.inc.php` file. The change comments out the inclusion of the `box-index-news.php` file until the BitFellas service is back up. 

* [`include_pouet_index/index_bootstrap.inc.php`](diffhunk://#diff-50de2330673747df26c6ab72b4f8acd58d86c9f3502f3072e8aa6e5bd944b019L14-R15): Commented out the line requiring `box-index-news.php` due to BitFellas being down.