### PR TITLE
Hide warning on edge case

### DIFF
--- a/add.php
+++ b/add.php
@@ -21,33 +21,35 @@ if (!$currentUser) {
   $message->message = "You got logged out somehow...";
 
 } else {
+  if (isset($array['type'])) {
 
-  switch ($_POST["type"]) {
-    case "oneliner":
-      {
-        $box = new PouetBoxIndexLatestOneliner();
-        $thing = "oneline";
-        $data = $_POST["message"];
-        $message->returnPage = "index.php";
-      } break;
-    case "post":
-      {
-        $box = new PouetBoxBBSPost($_POST["which"]);
-        $thing = "BBS post";
-        $data = $_POST["message"];
-        $message->returnPage = "topic.php?which=".(int)$_POST["which"];
-      } break;
-    case "bbs":
-      {
-        $box = new PouetBoxBBSOpen();
-        $thing = "bbs";
-        $data = $_POST["message"];
-        $message->returnPage = "index.php";
-      } break;
-    default:
-      {
-        $message->message = "not implemented!";
-      } break;
+    switch ($_POST["type"]) {
+      case "oneliner":
+        {
+          $box = new PouetBoxIndexLatestOneliner();
+          $thing = "oneline";
+          $data = $_POST["message"];
+          $message->returnPage = "index.php";
+        } break;
+      case "post":
+        {
+          $box = new PouetBoxBBSPost($_POST["which"]);
+          $thing = "BBS post";
+          $data = $_POST["message"];
+          $message->returnPage = "topic.php?which=".(int)$_POST["which"];
+        } break;
+      case "bbs":
+        {
+          $box = new PouetBoxBBSOpen();
+          $thing = "bbs";
+          $data = $_POST["message"];
+          $message->returnPage = "index.php";
+        } break;
+      default:
+        {
+          $message->message = "not implemented!";
+        } break;
+    }
   }
 }
 if ($box) {


### PR DESCRIPTION
This pull request includes changes to the `add.php` file to handle the presence of a 'type' key in the input array. The most important changes include adding a check for the 'type' key and ensuring the switch statement only executes if this key is set.

Changes to input handling:

* [`add.php`](diffhunk://#diff-87172570937491c46959d02cff87ee97841f68b2c32edcf81575072b24aadc1fR24): Added a check to determine if the 'type' key is set in the input array before executing the switch statement.
* [`add.php`](diffhunk://#diff-87172570937491c46959d02cff87ee97841f68b2c32edcf81575072b24aadc1fR54): Closed the newly added if-statement to ensure proper code execution flow.